### PR TITLE
Update thumbnails CSS/styling

### DIFF
--- a/packages/react-search-ui-views/src/Result.js
+++ b/packages/react-search-ui-views/src/Result.js
@@ -86,25 +86,8 @@ function Result({
 
       <div className="sui-result__body">
         {thumbnail && (
-          <div
-            className="sui-result__image"
-            style={{
-              maxWidth: "140px",
-              paddingLeft: "24px",
-              paddingTop: "10px"
-            }}
-          >
-            <img
-              src={thumbnail}
-              alt="thumbnail"
-              style={{
-                display: "block",
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                objectPosition: "center"
-              }}
-            />
+          <div className="sui-result__image">
+            <img src={thumbnail} alt="" />
           </div>
         )}
         <ul className="sui-result__details">

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
@@ -98,6 +98,18 @@
     }
   }
 
+  @include element('image') {
+    width: 140px;
+    padding-top: $sizeM;
+    padding-left: $sizeL;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+  }
+
   @include element('details') {
     padding: $sizeM;
     list-style: none;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
@@ -111,8 +111,8 @@
   }
 
   @include element('details') {
-    padding: $sizeM;
     list-style: none;
-    padding: $sizeM $sizeL
+    padding: $sizeM $sizeL;
+    margin: 0;
   }
 }

--- a/packages/react-search-ui-views/stories/Result.stories.js
+++ b/packages/react-search-ui-views/stories/Result.stories.js
@@ -79,7 +79,7 @@ storiesOf("Result", module)
         ...baseProps,
         result: {
           ...baseProps.result,
-          img: { raw: "https://via.placeholder.com/150x300" }
+          img: { raw: "https://via.placeholder.com/300x150" }
         },
         thumbnailField: "img"
       }}
@@ -91,7 +91,7 @@ storiesOf("Result", module)
         ...baseProps,
         result: {
           ...baseProps.result,
-          img: { raw: "https://via.placeholder.com/300x150" }
+          img: { raw: "https://via.placeholder.com/150x300" }
         },
         thumbnailField: "img"
       }}


### PR DESCRIPTION
## Description

@JasonStoltz let me know if this looks right to you / the image changes you were thinking of. :)

![thumbnail](https://user-images.githubusercontent.com/549407/77803487-74e80c00-703a-11ea-9bd6-ff3039cc1e55.gif) 

## List of changes

- Move inline styles to Sass
- Tweak styles to not force a width/height/object-fit but instead use default image ratios (if users want to implement their own custom object-fit styling, they can by all means override our CSS)
-  Fix tall vs wide thumbnail storybook examples (they were swapped it looks like)
- Minor CSS cleanup for `.sui-result__details`

## Associated Github Issues

https://github.com/elastic/search-ui/pull/467
https://github.com/elastic/search-ui/issues/425